### PR TITLE
docs(readme): removes pre-production warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 
 Library of styles, components and associated assets to build UIs for the web. Part of Buildit's Gravity design system.
 
----
-
-⚠️ This library is still under heavy development and does not yet have a stable API.
-
----
-
 ## Table of contents
 * [Using this library](#using-this-library)
     * [Pre-requisites](#pre-requisites)


### PR DESCRIPTION
We had a warning in the README about the API still being in flux. Now that we've released v1.0.0
this is no longer true, so this message is being removed.