### PR TITLE
ci(travis): enabled commitlint in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 install:
   - npm ci
 script:
-#  - commitlint-travis
+  - commitlint-travis
   - npm run-script styleguide
 before_deploy:
   - pip install --user awscli


### PR DESCRIPTION
Commitlint was originally turned off to prevent old commits from causing Travis CI to fail.

Closes #210 