### PR TITLE
fix(page-header): fixes linter issues

### DIFF
--- a/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
+++ b/src/ui-lib/sass/05-components/03-organisms/00-page-structure/_00-page-header.scss
@@ -6,7 +6,6 @@ $grav-page-heading-trigger-breakpoint: gravy-breakpoint(medium);
 // The child elements within therefore need to respect the maximum content
 // width ($grav-page-content-max-width) themselves, where necessary.
 body > header {
-  
   > div {
     @include grav-l-container;
 
@@ -21,7 +20,7 @@ body > header {
       padding-top: 0;
     }
   }
-  
+
   .grav-c-logo {
     display: block;
     max-height: 33px; // Otherwise IE11 makes it 150px tall :-(
@@ -31,9 +30,9 @@ body > header {
       width: 100%;
     }
   }
-  
 
-/* stylelint-disable-next-line selector-max-compound-selectors */
+
+  /* stylelint-disable-next-line selector-max-compound-selectors */
   a:hover .grav-c-logo {
     fill: $grav-co-neutral-warm-grey;
   }


### PR DESCRIPTION
**Description**
A few whitespace issues that the SASS linter doesn't like snuck in. This fixes those.