### PR TITLE
feat(deployment): add cdn publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Exclude build Output
 dist/
+cdn-dist/
 
 # Exclude unwanted stuff Pattern Lab generates
 dependencyGraph.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ deploy:
       ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" &&
       ~/.local/bin/aws s3 sync dist s3://${PROD_BUCKET} --delete --region=${PROD_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css"
+      ./scripts/cdn_publish.sh
     skip_cleanup: true
     on:
       branch: master

--- a/cdn-index.template
+++ b/cdn-index.template
@@ -1,7 +1,7 @@
 <html>
 <head><link rel="stylesheet" href="https://static.buildit.digital/gravity/v1.0.1/gravity.css"></head>
 <body>
-<h2>Versions</h2>
+<h1>Versions</h1>
 <ul>{versionlist}</ul>
 <a href="https://github.com/buildit/gravity-ui-web/blob/develop/CHANGELOG.md">See change log</a>
 </body>

--- a/cdn-index.template
+++ b/cdn-index.template
@@ -1,0 +1,8 @@
+<html>
+<head><link rel="stylesheet" href="https://static.buildit.digital/gravity/v1.0.1/gravity.css"></head>
+<body>
+<h2>Versions</h2>
+<ul>{versionlist}</ul>
+<a href="https://github.com/buildit/gravity-ui-web/blob/develop/CHANGELOG.md">See change log</a>
+</body>
+</html>

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+cdnGravityDir="gravity-ui-web"
+cdnDir="cdn-dist"
 version="$(git describe --abbrev=0 --tags)"
-mkdir -p cdn-dist/gravity/${version}
+mkdir -p ${cdnDir}/${cdnGravityDir}/${version}
 
-cp dist/ui-lib/* cdn-dist/gravity/${version}
+cp dist/ui-lib/* ${cdnDir}/${cdnGravityDir}/${version}
 
 versionList=""
 for version in $(git tag -l --sort=-committerdate); do
@@ -10,7 +12,7 @@ for version in $(git tag -l --sort=-committerdate); do
 done
 
 file_contents=$(<./cdn-index.template)
-echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
+echo "${file_contents//\{versionlist\}/$versionList}" > ${cdnDir}/${cdnGravityDir}/index.html
 
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --exclude ".DS_Store" --cache-control "max-age=3153600000, immutable"
+aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
+aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --exclude ".DS_Store" --cache-control "max-age=3153600000, immutable"

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -13,4 +13,4 @@ file_contents=$(<./cdn-index.template)
 echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
 
 ~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --cache-control "max-age=3153600000, immutable"l
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --cache-control "max-age=3153600000, immutable"

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+version="$(git describe --abbrev=0 --tags)"
+mkdir -p cdn-dist/gravity/${version}
+
+cp dist/ui-lib/*.css cdn-dist/gravity/${version}
+cp dist/ui-lib/*.js cdn-dist/gravity/${version}
+
+versionList=""
+for version in $(git tag -l --sort=-committerdate); do
+  versionList+="<li>${version}</li>"
+done
+
+file_contents=$(<./cdn-index.template)
+echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
+
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8"

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -13,4 +13,4 @@ file_contents=$(<./cdn-index.template)
 echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
 
 ~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --cache-control "max-age=3153600000, immutable"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --exclude ".DS_Store" --cache-control "max-age=3153600000, immutable"

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 cdnGravityDir="gravity-ui-web"
 cdnDir="cdn-dist"
-version="$(git describe --abbrev=0 --tags)"
+version="$(git describe --abbrev=0 --tags --match *v[0-1000].[0-1000].[0-1000]*)"
+# be sure we get only the version part and discard any prefix
+version=`expr $version : '.*\(v[0-9].*\)'`
+
 mkdir -p ${cdnDir}/${cdnGravityDir}/${version}
 
 cp dist/ui-lib/* ${cdnDir}/${cdnGravityDir}/${version}
 
 versionList=""
-for version in $(git tag -l --sort=-committerdate); do
-  versionList+="<li>${version}</li>"
+for thisVersion in $(git tag -l --sort=-committerdate); do
+  versionList+="<li>`expr $thisVersion : '.*\(v[0-9].*\)'`</li>"
 done
 
 file_contents=$(<./cdn-index.template)
 echo "${file_contents//\{versionlist\}/$versionList}" > ${cdnDir}/${cdnGravityDir}/index.html
 
-aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
-aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --exclude ".DS_Store" --cache-control "max-age=3153600000, immutable"
+~/.local/bin/aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
+~/.local/bin/aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8" --cache-control "max-age=3153600000, immutable" 
+~/.local/bin/aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8" --cache-control "max-age=3153600000, immutable"
+~/.local/bin/aws s3 sync ${cdnDir} s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --include "*" --exclude "*.js" --exclude "*.html" --exclude "*.css" --exclude ".DS_Store" --cache-control "max-age=3153600000, immutable" 

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -13,6 +13,6 @@ done
 file_contents=$(<./cdn-index.template)
 echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
 
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --delete --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8"

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -2,8 +2,7 @@
 version="$(git describe --abbrev=0 --tags)"
 mkdir -p cdn-dist/gravity/${version}
 
-cp dist/ui-lib/*.css cdn-dist/gravity/${version}
-cp dist/ui-lib/*.js cdn-dist/gravity/${version}
+cp dist/ui-lib/* cdn-dist/gravity/${version}
 
 versionList=""
 for version in $(git tag -l --sort=-committerdate); do
@@ -13,6 +12,5 @@ done
 file_contents=$(<./cdn-index.template)
 echo "${file_contents//\{versionlist\}/$versionList}" > cdn-dist/gravity/index.html
 
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.css" --content-type "text/css; charset=utf-8"
-~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.js" --content-type "application/javascript; charset=utf-8"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*" --include "*.html" --content-type "text/html; charset=utf-8" --cache-control "max-age=0"
+~/.local/bin/aws s3 sync cdn-dist s3://${CDN_BUCKET} --region=${PROD_BUCKET_REGION} --exclude "*.html" --cache-control "max-age=3153600000, immutable"l


### PR DESCRIPTION
Closes #191

**Description**
Add publishing of master branch *.css, *.js, and an index.html to an S3 backed CloudFront CDN that
stores versions (i.e. https://static.buildit.digital/gravity/v1.0.1/gravity.css)

Will demo before merge