### PR TITLE
chore(release): bumped alpha version for \`next\` npm tag publish

### DIFF
--- a/packages/gravity-ui-web/package-lock.json
+++ b/packages/gravity-ui-web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildit/gravity-ui-web",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gravity-ui-web/package.json
+++ b/packages/gravity-ui-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildit/gravity-ui-web",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "description": "Library of styles, components and associated assets to build UIs for the web. Part of Buildit's Gravity design system.",
   "main": "dist/gravity.js",
   "bundlesize": [


### PR DESCRIPTION
Version 3.0.0-alpha.1 published to npm as `next`