### PR TITLE
chore(build): cleanup file size history report

### DIFF
--- a/packages/gravity-ui-web/filesizehistory.html
+++ b/packages/gravity-ui-web/filesizehistory.html
@@ -38,9 +38,13 @@
 
         function getData(chartData) {
             var seriesRow = [];
+            var files = [];
             seriesRow.push('Date');
             for (var property in chartData.reports[0].files) {
-                seriesRow.push(property);
+                if (!property.endsWith("map") && !property.endsWith("json")) {
+                    seriesRow.push(property);
+                    files.push(property);
+                }
             };
             var rows = [];
             rows.push(seriesRow);
@@ -48,8 +52,8 @@
             chartData.reports.forEach(element => {
                 var dataRow = [];
                 dataRow.push(element.date);
-                for (const value of Object.values(element.files)) {
-                    dataRow.push(value.size);
+                for (const value of files) {
+                    dataRow.push(element.files[value].size);
                 };
                 rows.push(dataRow);
             });

--- a/scripts/cdn_publish.sh
+++ b/scripts/cdn_publish.sh
@@ -14,12 +14,7 @@ fi
 
 if [ ! -z "$cdnChanges" ]
 then
-  allVersions=`git tag --list --sort=-committerdate | grep  -E '^(gravity-ui-web-)?v[0-9]*.[0-9]*.[0-9]*'`
-
-  # First tag in the list will be the latest one, but may be prefixed (e.g. "gravity-ui-web-v1.2.3")
-  version=`echo $allVersions | cut -d" " -f1`
-  # be sure we get only the version part and discard any prefix
-  version=`expr $version : '.*\(v[0-9].*\)'`
+  source ./scripts/get_latest_version.sh
   
   mkdir -p ${cdnCurrentVersionGravityDir}/${version}
   cp packages/gravity-ui-web/dist/ui-lib/* ${cdnCurrentVersionGravityDir}/${version}

--- a/scripts/get_latest_version.sh
+++ b/scripts/get_latest_version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+allVersions=`git tag --list --sort=-committerdate | grep  -E '^(gravity-ui-web-)?v[0-9]*.[0-9]*.[0-9]*'`
+# First tag in the list will be the latest one, but may be prefixed (e.g. "gravity-ui-web-v1.2.3")
+version=`echo $allVersions | cut -d" " -f1`
+# be sure we get only the version part and discard any prefix
+version=`expr $version : '.*\(v[0-9].*\)'`

--- a/scripts/track_file_sizes.sh
+++ b/scripts/track_file_sizes.sh
@@ -12,11 +12,7 @@ if [ ! -z "$TRAVIS_COMMIT" ] && [[ "develop" == "$TRAVIS_BRANCH" || "master" == 
 then
   file-size-report -p $distDir -o $currentSizesFile
 
-  allVersions=`git tag --list --sort=-committerdate | grep -E '^(gravity-ui-web-)?v[0-9]*.[0-9]*.[0-9]*'`
-  # First tag in the list will be the latest one, but may be prefixed (e.g. "gravity-ui-web-v1.2.3")
-  version=`echo $allVersions | cut -d" " -f1`
-  # be sure we get only the version part and discard any prefix
-  version=`expr $version : '.*\(v[0-9].*\)'`
+  source ./scripts/get_latest_version.sh
 
   ~/.local/bin/aws s3 cp s3://${CDN_BUCKET}/$cdnGravityDir/$historyFileName $historyFile --region=${PROD_BUCKET_REGION} --quiet
 


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

refactor scripts to share common code and exclude files from history report

**Description**
Refactor two scripts to use common code that gets version from Git.  Modify file size history report to filter out map files and json files from report.