### PR TITLE
fix(related items): used breakpoint code from typography changes

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/03-articles/_00-related-items.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/03-articles/_00-related-items.scss
@@ -13,7 +13,7 @@
       display: block;
     }
 
-    @media all and (min-width: $grav-page-breakpoint-medium) {
+    @media all and (min-width: grav-breakpoint(medium)) {
       a {
         @include grav-font-size(4);
         display: block;


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

The breakpoint code was updated whist the related items feature was in PR, so it got overlooked for refactoring.