### PR TITLE
fix(hero): makes container overlap banner

### DIFF
--- a/packages/gravity-ui-web/package-lock.json
+++ b/packages/gravity-ui-web/package-lock.json
@@ -7954,7 +7954,7 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -12205,7 +12205,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         }
@@ -15378,7 +15378,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_hero.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_hero.scss
@@ -9,11 +9,6 @@
     object-position: center;
   }
 
-  .grav-o-container {
-    position: relative;
-    margin-top: 0;
-  }
-
   .grav-c-hero__container {
     @include grav-color-grp-a-apply('background-color', 'neutral', false);
 
@@ -30,7 +25,8 @@
 
     width: calc(100% - #{$grav-sp-m * 2});
     max-width: $grav-page-content-max-width - ($container-horizontal-max-margin * 2);
-    margin: ($container-vertical-shift * -1) auto 0;
+    position: relative; // Needed to let container DIV overlap banner IMG element
+    margin: (-1 * $container-vertical-shift) auto 0;
     padding: $container-vertical-shift $grav-sp-m $grav-sp-m $grav-sp-m;
 
     > * {


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

**Description**
I noticed a visual bug in the hero component, which was my fault. @ashblue originally had some relative positioning + z-index code to make the hero's white container overlap the banner image. I asked him to remove them - as I now realise, _incorrectly_ - thinking that the fact that the container is after the banner in the HTML source order, would suffice for it to visually overlap.

As it turns out, I wasn't quite right. While the `z-index`es are redundant, you do need to set `position: relative;` on the container to get the desired effect. So, this PR fixes that.

I'll be honest - I'm not 100% sure _why_ that's the case. Working off some experimentation @dw-buildit started, we've established that if the `<img>` was a `<div>` it would just work. But as soon as you use an `<img>` the (background) of the following element will _not_ overlap it. Here's a CodePen to demonstrate: https://codepen.io/cirrus/pen/joaPJa