### PR TITLE
fix(callout): tweaks layout

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_callout.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_callout.scss
@@ -1,10 +1,11 @@
 .grav-c-callout {
   p {
     @include grav-font-size(2);
-    line-height: 100%;
+    line-height: 1.2;
 
     @media all and (min-width: grav-breakpoint(small)) {
-      margin-right: 1.5em;
+      max-width: 24rem;
+      margin-right: $grav-sp-l;
     }
 
     @media all and (min-width: grav-breakpoint(medium)) {
@@ -13,18 +14,19 @@
   }
 
   .grav-c-callout__columns {
-    max-width: $grav-page-content-max-width;
-    margin: $grav-sp-vertical-gap auto;
-    padding: 0 $grav-sp-m;
+    @include grav-l-container;
+
+    padding-top: $grav-sp-vertical-gap;
+    padding-bottom: $grav-sp-vertical-gap;
 
     @media all and (min-width: grav-breakpoint(small)) {
       display: flex;
-      margin-bottom: $grav-sp-vertical-gap;
+      align-items: center;
       justify-content: space-between;
     }
   }
 
   .grav-c-three-column-list-justified {
-    max-width: 18em;
+    max-width: 28rem;
   }
 }


### PR DESCRIPTION
**Description**
Tweaks the layout of the callout component to better fit the website designs (some issues were spotted in the website PR: buildit/buildit#258

Specifically:

* Uses our container mixin (which, in effect does the same as `.grav-o-container`) to ensure that the inner DIV expands to the full width of the page content area
* Switches margin to padding on the outer DIV to create the desired spacing _within_ this component
* Switches some sizes from `em` to `rem` so that they stay consistent, even when text sizes change or get scaled
* Adds a max-width to the paragraph to match the concept designs more closely