### PR TITLE
feat(column layout): adds mixin for full-width items

### DIFF
--- a/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
+++ b/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
@@ -60,7 +60,7 @@
   // its top margin reinstated. Likewise, subsequent items that
   // would have otherwise been in the first row also need their
   // top margins reinstated.
-  :not(:first-child),
+  &:not(:first-child),
   + :nth-child(-n + #{$column-count}) {
     margin-top: $margin-top;
   }

--- a/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
+++ b/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
@@ -3,24 +3,16 @@
   $column-spacing: $column-gap / 2;
   display: flex;
   flex-wrap: wrap;
+  margin-right: -$column-spacing;
+  margin-left: -$column-spacing;
   padding-right: 0;
   padding-left: 0;
 
   // All children start with margin on their sides
   > * {
-    width: calc((100% - #{(($column-count - 1) * 2) * $column-spacing}) / #{$column-count});
+    width: calc((100% - #{($column-count * 2) * $column-spacing}) / #{$column-count});
     margin-right: $column-spacing;
     margin-left: $column-spacing;
-  }
-
-  // Select the right-most column's children and remove the right margin
-  > *:nth-child(#{$column-count}n) {
-    margin-right: 0;
-  }
-
-  // Select the left-most column's children and remove the left margin
-  > *:nth-child(#{$column-count}n - #{$column-count - 1}) {
-    margin-left: 0;
   }
 
   // Select the top row's children and remove the top margin
@@ -54,5 +46,22 @@
     &:last-child {
       margin-right: 0;
     }
+  }
+}
+
+// a mixin that can be applied to items in a "no-danglies" column layout
+// to make them span the full width of the parent element.
+@mixin grav-l-column-item-full-width($column-count: 2, $margin-top: $grav-sp-vertical-gap) {
+  flex-basis: 100%;
+
+  // Multi-column layouts remove the top margin of all items in
+  // the first row. If the item being stretched is one of those,
+  // then it will necessarily create a new row and therefore need
+  // its top margin reinstated. Likewise, subsequent items that
+  // would have otherwise been in the first row also need their
+  // top margins reinstated.
+  :not(:first-child),
+  + :nth-child(-n + #{$column-count}) {
+    margin-top: $margin-top;
   }
 }

--- a/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
+++ b/packages/gravity-ui-web/src/sass/01-tools/_layouts.scss
@@ -42,10 +42,6 @@
 @mixin grav-l-column-no-danglies {
   > * {
     flex-grow: 1;
-
-    &:last-child {
-      margin-right: 0;
-    }
   }
 }
 

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_list-cards-basic.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_list-cards-basic.scss
@@ -8,7 +8,7 @@
   }
 
   @media all and (min-width: grav-breakpoint(large)) {
-    @include grav-l-column-layout($columns, $grav-sp-l);
+    @include grav-l-column-layout($columns, $grav-sp-xl);
     @include grav-l-column-no-danglies;
 
     // Callouts go full-width

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_list-cards-basic.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_list-cards-basic.scss
@@ -1,40 +1,19 @@
 .grav-c-list-cards-basic {
   @include grav-l-column-list;
 
+  $columns: 2;
+
   > li + li {
     margin-top: $grav-sp-xl;
   }
 
   @media all and (min-width: grav-breakpoint(large)) {
-    @include grav-l-column-layout(2, $grav-sp-l);
+    @include grav-l-column-layout($columns, $grav-sp-l);
     @include grav-l-column-no-danglies;
 
-    margin-right: -$grav-sp-l;
-    margin-left: -$grav-sp-l;
-
-    > * {
-      margin-right: 0;
-      margin-left: 0;
-    }
-
-    > li {
-      padding-right: $grav-sp-l;
-      padding-left: $grav-sp-l;
-    }
-
-    > {
-      // Callouts go full-width
-      .grav-c-list-cards-basic__item--callout {
-        flex-basis: 100%;
-      }
-
-      // Special cases that need top margin reinstated:
-      // - any callout (except in 1st position)
-      .grav-c-list-cards-basic__item--callout:not(:first-child),
-      // - the 2nd card, if it follows a callout
-      .grav-c-list-cards-basic__item--callout + li:nth-child(2) {
-        margin-top: $grav-sp-xl;
-      }
+    // Callouts go full-width
+    > .grav-c-list-cards-basic__item--callout {
+      @include grav-l-column-item-full-width($columns, $grav-sp-xl);
     }
   }
 }


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

The `.grav-c-list-cards-basic` component has an element modifier class that can stretch a single
card to span both columns. The CSS logic behind it might be useful to other column layouts, so this
change extracts and genericises it into a mixin that can be used in conjunction with any "no
danglies" column layout. It also updates the `.grav-c-list-cards.basic` class to use this mixin.