### PR TITLE
fix: adds missing width property to grav-l-container() mixin

### DIFF
--- a/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
+++ b/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
@@ -1,5 +1,6 @@
 // a simple mixin to create a container for the page
 @mixin grav-l-container($no-margin: false) {
+  width: 100%;
   max-width: $grav-page-content-max-width;
 
   // IE10+ bug that happens when using margin: auto


### PR DESCRIPTION
**Description**
Fixes a long-standing bug that's been irking me:

The `grav-l-container` mixin, that is used by the `.grav-o-container` class and also within the page
header and footer components, sets a `max-width` but does not set an explicit `width`. Normally this is not an issue since block elements will naturally expand horizontally to fill the available space.
However, when used on direct descendents of `<body>`, which are laid out by flexbox for the sticky
footer behaviour), the elements shrink to fit the width of their content which causes them to then
appear centered on the page. This fix adds a `width: 100%;` to the mixin, which counteracts this
behaviour.

**Note**: I'm fixing this on `develop` since this bug has been present forever and I think it makes sense to do a `2.x` path release to distribute this fix. Once merged, I'll do a mini PR to merge this and anything else lurking in `develop` up into `next`.