### PR TITLE
fix: undoes layout regression caused by previous "fix"

### DIFF
--- a/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
+++ b/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
@@ -1,6 +1,6 @@
 // a simple mixin to create a container for the page
 @mixin grav-l-container($no-margin: false) {
-  width: 100%;
+  width: calc(100% - #{2 * $grav-page-content-inset});
   max-width: $grav-page-content-max-width;
 
   // IE10+ bug that happens when using margin: auto

--- a/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
+++ b/packages/gravity-ui-web/src/ui-lib/sass/01-tools/_container.scss
@@ -1,6 +1,5 @@
 // a simple mixin to create a container for the page
 @mixin grav-l-container($no-margin: false) {
-  width: calc(100% - #{2 * $grav-page-content-inset});
   max-width: $grav-page-content-max-width;
 
   // IE10+ bug that happens when using margin: auto
@@ -12,7 +11,11 @@
     }
   }
 
-  @if (not $no-margin) {
+  @if ($no-margin) {
+    width: 100%;
+  }
+  @else {
+    width: calc(100% - #{2 * $grav-page-content-inset});
     margin-right: $grav-page-content-inset;
     margin-left: $grav-page-content-inset;
   }


### PR DESCRIPTION
A recent fix to the container mixin incorrectly set the width as 100%, which failed to take into
account the outer margins that are applied on smaller viewports. This cause container components to
horizontally overflow the viewport. This fixes that by replacing 100% with a suitable calc()
expression.