### PR TITLE
fix(container): undoes layout regression caused by previous "fix"

### DIFF
--- a/packages/gravity-ui-web/src/sass/01-tools/_container.scss
+++ b/packages/gravity-ui-web/src/sass/01-tools/_container.scss
@@ -1,6 +1,6 @@
 // a simple mixin to create a container for the page
 @mixin grav-l-container($no-margin: false) {
-  width: 100%;
+  width: calc(100% - #{2 * $grav-sp-page-content-inset});
   max-width: $grav-page-content-max-width;
   margin-right: $grav-sp-page-content-inset;
   margin-left: $grav-sp-page-content-inset;
@@ -16,6 +16,7 @@
   }
 
   @media (min-width: grav-breakpoint(extra-large)) {
+    width: 100%;
     margin-right: auto;
     margin-left: auto;
   }


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

Updated fix for @james-nash's stupid mistake (his words) for the `next` branch.