### PR TITLE
refactor(footer): ensure margin above footer

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/00-page-structure/_01-page-footer.scss
@@ -2,6 +2,7 @@ body > footer {
   @include grav-color-grp-b-apply('border-bottom-color', 'accent');
   @include grav-font-size(-1);
 
+  margin-top: $grav-sp-vertical-gap;
   padding: $grav-sp-l 0;
   border-bottom-width: $grav-st-thickness-medium;
   border-bottom-style: solid;


### PR DESCRIPTION
Ensure there is the usual vertical margin above the footer, regardless of the content that precedes it.

This should play nicely with preceding containers that specify their own bottom margin as the margins will collapse.