### PR TITLE
refactor(basic card): use neutral alt bg color for slow loading images

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/00-page-structure/_02-page-intro.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/00-page-structure/_02-page-intro.scss
@@ -26,6 +26,7 @@
 
   img {
     @include grav-decoration-notch-out($grav-c-page-intro-notch-size, $grav-sp-s);
+    @include grav-color-grp-a-apply('background', 'neutral-alt', true);
 
     width: 100%;
     max-height: 30rem;

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
@@ -16,6 +16,7 @@
   }
 
   img {
+    @include grav-color-grp-a-apply('background', 'neutral-alt', true);
     display: block;
     width: 100%;
     height: $card-image-height;


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

Adds a subtle background color to the card `img` element so that whilst loading there is a representation to the user of the notch etc.