### PR TITLE
fix(callout): remove margin from list when in columns

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_callout.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_callout.scss
@@ -1,9 +1,11 @@
 .grav-c-callout {
+  $columns-breakpoint: small;
+
   p {
     @include grav-font-size(2);
     line-height: 1.2;
 
-    @media all and (min-width: grav-breakpoint(small)) {
+    @media all and (min-width: grav-breakpoint($columns-breakpoint)) {
       max-width: 24rem;
       margin-right: $grav-sp-l;
     }
@@ -19,7 +21,7 @@
     padding-top: $grav-sp-vertical-gap;
     padding-bottom: $grav-sp-vertical-gap;
 
-    @media all and (min-width: grav-breakpoint(small)) {
+    @media all and (min-width: grav-breakpoint($columns-breakpoint)) {
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -28,5 +30,9 @@
 
   .grav-c-three-column-list-justified {
     max-width: 28rem;
+
+    @media all and (min-width: grav-breakpoint($columns-breakpoint)) {
+      margin-top: 0;
+    }
   }
 }


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

Remove the margin above the three column list when the callout is in two column mode.