### PR TITLE
Feature/padding utilities

### DIFF
--- a/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/00-basic-page.njk
+++ b/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/00-basic-page.njk
@@ -1,6 +1,6 @@
 {%- include 'organisms-page-header' -%}
 {%- block pageContent %}
-<main>
+<main class="grav-u-pb-xl">
   {% block mainContent -%}
     {#
       Just some dummy example content.

--- a/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/00-basic-page.njk
+++ b/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/00-basic-page.njk
@@ -1,6 +1,6 @@
 {%- include 'organisms-page-header' -%}
 {%- block pageContent %}
-<main class="grav-u-pb-xl">
+<main>
   {% block mainContent -%}
     {#
       Just some dummy example content.

--- a/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/01-error-page.njk
+++ b/packages/gravity-ui-nunjucks/src/_patterns/04-templates/00-page-layouts/01-error-page.njk
@@ -4,7 +4,7 @@
 {%- from 'atoms-ascii-art' import asciiArt -%}
 
 {%- block pageContent %}
-  <main class="grav-o-container">
+  <main class="grav-o-container grav-u-pb-xl">
     <section class="grav-o-section grav-u-text-centered">
       {{ asciiArt( ascii ) | safe }}
       <h1>{{title}}</h1>

--- a/packages/gravity-ui-web/src/sass/00-settings/_spacing.scss
+++ b/packages/gravity-ui-web/src/sass/00-settings/_spacing.scss
@@ -34,6 +34,18 @@ $grav-sp-l: grav-sp-calc(1);
 $grav-sp-xl: grav-sp-calc(2);
 $grav-sp-xxl: grav-sp-calc(3);
 
+
+// Global map of one-dimensional space sizes, plus zero
+$grav-sp-map: (
+  'none': 0,
+  'xs': $grav-sp-xs,
+  's': $grav-sp-s,
+  'm': $grav-sp-m,
+  'l': $grav-sp-l,
+  'xl': $grav-sp-xl,
+  'xxl': $grav-sp-xl
+);
+
 // Global set of two-dimensional insets (typically used as padding values)
 $grav-sp-inset-xs: $grav-sp-xs $grav-sp-xs;
 $grav-sp-inset-s: $grav-sp-s $grav-sp-s;

--- a/packages/gravity-ui-web/src/sass/06-utilities/_padding.scss
+++ b/packages/gravity-ui-web/src/sass/06-utilities/_padding.scss
@@ -1,0 +1,11 @@
+$grav-sides: (top, bottom, left, right);
+$grav-spaces-map: ('xs': $grav-sp-s,'s': $grav-sp-s, 'm': $grav-sp-m, 'l': $grav-sp-l, 'xl': $grav-sp-xl, 'xxl': $grav-sp-xl);
+
+// Generate utility classes for available spacing sizes
+@each $name, $space in $grav-spaces-map {
+  @each $side in $grav-sides {
+    .grav-u-p#{str-slice($side, 0, 1)}-#{$name} {
+      padding-#{$side}: #{$space} !important;
+    }
+  }
+}

--- a/packages/gravity-ui-web/src/sass/06-utilities/_padding.scss
+++ b/packages/gravity-ui-web/src/sass/06-utilities/_padding.scss
@@ -1,8 +1,7 @@
 $grav-sides: (top, bottom, left, right);
-$grav-spaces-map: ('xs': $grav-sp-s,'s': $grav-sp-s, 'm': $grav-sp-m, 'l': $grav-sp-l, 'xl': $grav-sp-xl, 'xxl': $grav-sp-xl);
 
 // Generate utility classes for available spacing sizes
-@each $name, $space in $grav-spaces-map {
+@each $name, $space in $grav-sp-map {
   @each $side in $grav-sides {
     .grav-u-p#{str-slice($side, 0, 1)}-#{$name} {
       padding-#{$side}: #{$space} !important;

--- a/packages/gravity-ui-web/src/sass/06-utilities/_utilities.all.scss
+++ b/packages/gravity-ui-web/src/sass/06-utilities/_utilities.all.scss
@@ -3,3 +3,4 @@
 // triangle, eg. hide helper class.
 @import 'color-schemes';
 @import 'text';
+@import 'padding';


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

adds a suite of padding utility classes

Description
Currently we have a problem with the footer not having enough space above it. After much discussion in person and on this PR #323 I've added a function that will generate a suite of padding utility functions. I've added a class to the main element which will add the padding we need. They should be useful in the future for other cases where extra/less padding is required.

**Checklist**
### SASS

- [x] The SASS (and related pattern files) follow the [naming conventions](/docs/naming-conventions.md), architecture and structure outlined in the documentation.

