### PR TITLE
chore(travis.yml): reinstates pyenv, but with correct version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - npm run-script build
   - npm run test
 before_deploy:
+  - pyenv global 3.7
   - pip3 install --user awscli
   - ./scripts/track_file_sizes.sh
 deploy:


### PR DESCRIPTION
**Description**
Turns out, contrary to their docs, Travis CI's environment still default to Python 2.x. Since we need 3.x, I've had to reinstate the `pyenv` call I recently removed. However, after some trial and error, I have determined that version `3.7` is available and works (previously we were trying to install `3.6` which was no longer an available version and therefore broke the builds).
