### PR TITLE
chore(travis.yml): updates python version to fix deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - npm run-script styleguide
   - npm run test
 before_deploy:
-  - pyenv global 3.6
+  - pyenv global 3.7
   - pip3 install --user awscli
   - ./scripts/track_file_sizes.sh
 deploy:


### PR DESCRIPTION
**Description**
Travis builds from `develop` are now failing for the same reason that they recently were on `next`: `pyenv` is trying to switch to a Python version that is no longer available in the current Travis Linux images. The deployment therefore fails.

Example: https://travis-ci.org/buildit/gravity-ui-web/builds/578459635#L768

This PR applies the same change we used to fix this issue in `next` (see PR #340), i.e. it bumps the python version being installed.
