### PR TITLE
Fix/next/atoms a11y bugs

### DIFF
--- a/packages/gravity-ui-nunjucks/src/components/01-atoms/06-buttons/08-toggle-menu/toggle-menu.config.json
+++ b/packages/gravity-ui-nunjucks/src/components/01-atoms/06-buttons/08-toggle-menu/toggle-menu.config.json
@@ -1,5 +1,6 @@
 {
   "context": {
-    "text": "Toggle menu"
+    "text": "Toggle menu",
+    "pressed": false
   }
 }

--- a/packages/gravity-ui-web/gulp/ui-lib.js
+++ b/packages/gravity-ui-web/gulp/ui-lib.js
@@ -164,8 +164,8 @@ function svgSymbolsTask() {
         // Add an ID to the <title> element of each SVG symbol
         // This is so that we can later reference it via
         // aria-labelledby for better a11y.
-        $('symbol').each(() => {
-          const symbol = $(this);
+        $('symbol').each((index, element) => {
+          const symbol = $(element);
           const symbolId = symbol.attr('id');
           const title = symbol.children('title');
           title.attr('id', symbolId + titleIdSuffix);


### PR DESCRIPTION
Closes #369

**Description**
Fixes most of the a11y issues in atom components raised in #369:

* ~05-icon-button~
    * It turns out there was a bug in our build scripts which prevented the `id` attributes from being added to our SVG symbols' `<title>` element. Therefore, when those titles were being referenced from elsewhere via `aria-labelledby="[ id ]"`, the IDs being referenced were missing.
* _05-cite_
    * ⚠️ **Not fixed**, because this needs to be fixed upstream in `gravity-particles`. I have raised an issue there: buildit/gravity-particles#30
* ~08-toggle-menu~
    * Just an omission in the context data for that template that cause `aria-pressed` to have an empty value instead of `"false"`.
* ~06-icon-toggle-button~
    * Got fixed when the icon button got fixed.
