### PR TITLE
fix(package): explicitly states compatibility with newer NodeJS versions

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/dubnium

--- a/package.json
+++ b/package.json
@@ -28,9 +28,5 @@
     "commitizen": {
       "path": "./node_modules/cz-lerna-changelog"
     }
-  },
-  "engines": {
-    "node": "^8.11.1",
-    "npm": "^5.8.0"
   }
 }

--- a/packages/gravity-ui-web/package.json
+++ b/packages/gravity-ui-web/package.json
@@ -110,8 +110,8 @@
     "normalize-scss": "^7.0.1"
   },
   "engines": {
-    "node": "^8.11.1",
-    "npm": "^5.8.0"
+    "node": ">=8",
+    "npm": ">=5.8.0"
   },
   "eyeglass": {
     "sassDir": "src/ui-lib/sass",


### PR DESCRIPTION
* Expands the range of "compatible" Node and NPM versions to include releases newer than 8.x. This means that _consumers_ that `npm install` Gravity won't see warning messages if they're on Node versions later than 8 (currently they will)
* Updates `.nvmrc` to use the latest Node 10.x ("LTS Dubnium") versions as 8.x is no longer supported and pretty old now.

**Note to reviewers:** This PR is on the `develop` branch (i.e. Gravity 2.x)
