### PR TITLE
fix(a11y): fix card violations

### DIFF
--- a/packages/gravity-ui-nunjucks/src/components/02-molecules/04-cards/00-card-basic/card-basic.njk
+++ b/packages/gravity-ui-nunjucks/src/components/02-molecules/04-cards/00-card-basic/card-basic.njk
@@ -5,7 +5,7 @@
 <div class="grav-c-card-basic">
   {% if href %}<a href="{{ href }}">{% endif %}
     {{ image(img.src, img.alt, img.class) | safe }}
-    {% if href %}{{ inlineSvg('decoration-arrow-right') }}{% endif %}
+    {% if href %}{{ inlineSvg('decoration-arrow-right', customLabel="See more") }}{% endif %}
     <h3 class="grav-c-card-basic__title">{{ title }}</h3>
   {% if href %}</a>{% endif %}
   <p>{{ content }}</p>

--- a/packages/gravity-ui-web/README.md
+++ b/packages/gravity-ui-web/README.md
@@ -113,7 +113,7 @@ Currently, Gravity's SVG symbol definitions need to be inlined into your HTML. T
 
 The `height` and `width` properties should be set to ensure that your inline SVG's intrinsic size matches the aspect ratio of the referenced symbol. If you omit them, browsers will [default to a width of `150px` and a height of `100px`](https://www.sitepoint.com/replaced-elements-html-myths-realities/) and the chosen symbol will appear centered within that area.
 
-The `aria-lebblledby` should be set to provide a text alternative for the SVG (equivalent to `alt` in `<img>` elements). All of Gravity's SVG symbol definitions contain alternative texts in their `<title>` elements and these have unique `id`s, so that they can be referenced from elsewhere via `aria-lebblledby`.
+The `aria-labelledby` should be set to provide a text alternative for the SVG (equivalent to `alt` in `<img>` elements). All of Gravity's SVG symbol definitions contain alternative texts in their `<title>` elements and these have unique `id`s, so that they can be referenced from elsewhere via `aria-labelledby`.
 
 You can look up these values manually in [Gravity's pattern library](http://style.buildit.digital/?p=particles-svg-symbols). For convenience and possible automation, Gravity also ships with a JSON file that contains the symbol and title IDs and the intrinsic width and height values for every available symbol. The format of this file is as follows:
 


### PR DESCRIPTION
Closes #375 

**Description**
Fix accessibility violations regarding to the `card-base` component. This component is using an `inlineSVG` element to show the SVG symbol `decorative-arrow-right` which by default doesn't have a title to be referenced. This was causing an ARIA error since there was mismatch between the `aria-labelledby` and the no existent title of that particular SVG symbol.

NOTE: Other solution could have been to add a `<title>` to the SVG symbol `decorative-arrow-right` but this title can change depending on the context where it is being used.

Also this PR fixes a typo in the README file.
