### PR TITLE
fix(a11y): add alternative description to hero image

### DIFF
--- a/packages/gravity-ui-nunjucks/src/components/03-organisms/00-page-structure/02-hero/hero.config.json
+++ b/packages/gravity-ui-nunjucks/src/components/03-organisms/00-page-structure/02-hero/hero.config.json
@@ -2,6 +2,7 @@
   "context": {
     "title": "Bold, heroic title text",
     "message": "Lorem ipsum dolor sit amet, <strong>consectetur adipiscing</strong> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "image": "/images/img-16x9.png"
+    "image": "/images/img-16x9.png",
+    "altDescription": "Heroic image"
   }
 }

--- a/packages/gravity-ui-nunjucks/src/components/03-organisms/00-page-structure/02-hero/hero.njk
+++ b/packages/gravity-ui-nunjucks/src/components/03-organisms/00-page-structure/02-hero/hero.njk
@@ -1,5 +1,5 @@
 <section class="grav-c-hero">
-  <img class="grav-c-hero__banner" src="{{ image }}" />
+  <img class="grav-c-hero__banner" src="{{ image }}" alt="{{ altDescription }}" />
 
   <div class="grav-c-hero__container">
     {% block heroContainer %}


### PR DESCRIPTION
Closes #377 

**Description**
In order to comply with accessibility requirements this PR adds an alternative description to the image of the `hero` component. This fix also solve `homepage` and `page-homepage` violations`.
