### PR TITLE
feat: improves picture element layout

### DIFF
--- a/packages/gravity-ui-web/src/sass/03-elements/_media.scss
+++ b/packages/gravity-ui-web/src/sass/03-elements/_media.scss
@@ -3,3 +3,21 @@ svg {
   max-width: 100%;
   height: auto;
 }
+
+
+picture {
+  // Avoid slight gap below <img> when the
+  // <picture> is display:block due to <img>
+  // being display:inline by default.
+  // (The <img> is aligned with baseline, not
+  // the bottom of the text box)
+  display: inline-block;
+
+  > img {
+    display: block;
+
+    // Avoid <img> inside <picture> having
+    // top margin applied by the * + * rule
+    margin-top: 0;
+  }
+}

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
@@ -27,7 +27,7 @@
     display: block;
     position: relative;
 
-    > img {
+    img {
       @include grav-decoration-notch-in;
     }
 

--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_copy-ostentatious.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_copy-ostentatious.scss
@@ -25,6 +25,10 @@
     margin: auto;
   }
 
+  picture {
+    display: block;
+  }
+
   @media (min-width: grav-breakpoint(medium)) {
     padding-right: $grav-sp-l;
     padding-left: $grav-sp-l;


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

**Description**
There can be some subtle layout glitches when `<img>` elements are wrapped in `<picture>` elements - especially when they also contain `<source>` elements before the image. This has been encountered on the Buildit website. These changes aim to avoid such problems and let  consumers use `<picture>`
without layout side-effects.