### PR TITLE
fix(card-basic): fixes size of picture elements

### DIFF
--- a/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/03-organisms/_card-basic.scss
@@ -23,6 +23,10 @@
     object-fit: cover;
   }
 
+  picture {
+    display: block;
+  }
+
   > a {
     display: block;
     position: relative;


### PR DESCRIPTION
affects: @buildit/gravity-ui-web

When cards wrap their image in a <picture> element, it doesn't fill the width of the card as it
should. This fixes that.