### PR TITLE
feat(logotype): changes SVG colouring and adds new logotype component

### DIFF
--- a/packages/gravity-ui-nunjucks/src/components/00-particles/05-logos-and-icons/README.md
+++ b/packages/gravity-ui-nunjucks/src/components/00-particles/05-logos-and-icons/README.md
@@ -20,6 +20,9 @@ Without further styling, the logo or icon will appear as black (`#000`) on a tra
 }
 ```
 
+## Multi-coloured SVGs
+Some of the available SVGs contain shapes that can be independently coloured. By default, they will all share the same current colour. However, you can selectively re-colour them via the <code>--grav-co-svg-hl-1 / 2 / 3</code> custom properties. Refer to the preview tables in the pattern library to see what regions of an SVG those custom properties correspond to.
+
 ## Generating the SVG symbols
 
 `gravity-ui-web` uses an SVG icon system instead of an icon font. Furthermore, [we use `<symbols>` rather than `<defs>`](https://css-tricks.com/svg-symbol-good-choice-icons/), so that we don't need to specify the `viewBox` each time a glyph is referenced. The benefits of this approach are covered in the CSS-Tricks [Icon System with SVG Sprites](https://css-tricks.com/svg-sprites-use-better-icon-fonts/) article. Of particular appeal to us were the following:

--- a/packages/gravity-ui-nunjucks/src/components/00-particles/05-logos-and-icons/logos-and-icons.njk
+++ b/packages/gravity-ui-nunjucks/src/components/00-particles/05-logos-and-icons/logos-and-icons.njk
@@ -1,4 +1,5 @@
 {% from '@inline-svg-symbol' import inlineSvg %}
+{% from '@color-schemes' import colorProp %}
 
 <table class="sg-symbol-table">
   <thead>
@@ -12,7 +13,7 @@
   <tbody>
   {% for symbol in symbols %}
     <tr>
-      <td>
+      <td class="sg-svg-highlight">
         {{ inlineSvg(symbol.symbolId, symbol.width, symbol.height, symbol.titleId, 'sg-symbol-table__preview', 'Arrow right' ) }}
       </td>
       <td>
@@ -28,3 +29,18 @@
   {% endfor %}
   </tbody>
 </table>
+<p>Some SVGs have shapes that can be independently filled via the <code>--grav-co-svg-hl-*</code> custom properties. To visualise this, the above SVGs have such regions coloured in as follows:</p>
+<ul class="sg-highlight-preview sg-svg-highlight">
+  <li>
+    {{ colorProp('--grav-co-svg-hl-1') | safe }}
+  </li>
+  <li>
+    {{ colorProp('--grav-co-svg-hl-2') | safe }}
+  </li>
+  <li>
+    {{ colorProp('--grav-co-svg-hl-3') | safe }}
+  </li>
+</ul>
+
+
+

--- a/packages/gravity-ui-nunjucks/src/components/01-atoms/04-media/20-logotype/README.md
+++ b/packages/gravity-ui-nunjucks/src/components/01-atoms/04-media/20-logotype/README.md
@@ -1,5 +1,5 @@
 ## Purpose
 
-Use this component wherever the Buildit logotype (i.e. the stylised "buildit @ wipro digital" text) needs to be displayed.
+Use this component wherever the Buildit logotype (i.e. the stylised "buildit | wipro digital" text) needs to be displayed.
 
-It uses the `inline-svg-symbol` atom (and therefore depends on `symbols.svg` having been inlined into your HTML document), but hard-codes the correct symbol ID and also sets the intrinsic width and height.
+It displays the correct SVG symbol and also applies the current group B accent colour to the "buildit |" portion.

--- a/packages/gravity-ui-nunjucks/src/components/01-atoms/04-media/20-logotype/logotype.njk
+++ b/packages/gravity-ui-nunjucks/src/components/01-atoms/04-media/20-logotype/logotype.njk
@@ -1,2 +1,2 @@
 {%- from '@inline-svg-symbol' import inlineSvg -%}
-{{- inlineSvg('logo-buildit-logotype', 300, 33) | safe -}}
+{{- inlineSvg('logo-buildit-logotype', 300, 33, false, 'grav-c-logotype') | safe -}}

--- a/packages/gravity-ui-nunjucks/src/sass/components/_svg-highlights.scss
+++ b/packages/gravity-ui-nunjucks/src/sass/components/_svg-highlights.scss
@@ -1,0 +1,14 @@
+.sg-svg-highlight {
+  --grav-co-svg-hl-1: var(--grav-co-grp-b-accent);
+  --grav-co-svg-hl-2: var(--grav-co-grp-b-control-alt);
+  --grav-co-svg-hl-3: var(--grav-co-grp-b-accent-attention);
+}
+
+.sg-highlight-preview {
+  list-style-type: none;
+  padding: 0;
+
+  li {
+    padding: 0;
+  }
+}

--- a/packages/gravity-ui-nunjucks/src/sass/pattern-scaffolding.scss
+++ b/packages/gravity-ui-nunjucks/src/sass/pattern-scaffolding.scss
@@ -48,6 +48,7 @@
 @import 'components/fonts';
 @import 'components/label';
 @import 'components/sub-heading';
+@import 'components/svg-highlights';
 
 
 // === Utilities layer ===

--- a/packages/gravity-ui-web/src/sass/03-elements/_media.scss
+++ b/packages/gravity-ui-web/src/sass/03-elements/_media.scss
@@ -28,20 +28,28 @@ svg {
   fill: currentColor;
 }
 
+/*
+  To enable recolouring of SVG symbols that get pulled in
+  via <use> we have to use CSS custom properties. This is
+  because the original SVG is essentially cloned into a
+  shadow DOM of the parent <svg> and so, you can't select
+  elements within it via CSS selectors. However, some
+  values including custom properties are inherited across
+  the shadow DOM boundary.
+*/
 // The following class names are defined in the source SVGs
 // provided by Gravity Particles and thus deviate from our
-// usual class-naming conventions.
-
+// usual class-naming conventions:
 // stylelint-disable selector-class-pattern
 .grav-svg-hl-1 {
-  @include grav-color-apply('fill', 'b', 'accent');
+  fill: var(--grav-co-svg-hl-1, currentColor);
 }
 
 .grav-svg-hl-2 {
-  @include grav-color-apply('fill', 'b', 'control-alt');
+  fill: var(--grav-co-svg-hl-2, currentColor);
 }
 
 .grav-svg-hl-3 {
-  @include grav-color-apply('fill', 'b', 'accent-attention');
+  fill: var(--grav-co-svg-hl-3, currentColor);
 }
 // stylelint-enable selector-class-pattern

--- a/packages/gravity-ui-web/src/sass/05-components/01-atoms/04-media/_10-logotype.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/01-atoms/04-media/_10-logotype.scss
@@ -1,0 +1,3 @@
+.grav-c-logotype {
+  --grav-co-svg-hl-1: var(--grav-co-grp-b-accent);
+}

--- a/packages/gravity-ui-web/src/sass/05-components/01-atoms/_atoms.all.scss
+++ b/packages/gravity-ui-web/src/sass/05-components/01-atoms/_atoms.all.scss
@@ -1,6 +1,7 @@
 @import '01-block-text/pullout';
 @import '01-block-text/05-ascii-art';
 @import '02-lists/01-list-horizontal';
+@import '04-media/10-logotype';
 @import '04-media/24-image';
 @import '04-media/25-icon';
 @import '06-buttons/05-icon-button';

--- a/packages/gravity-ui-web/src/sass/debug.scss
+++ b/packages/gravity-ui-web/src/sass/debug.scss
@@ -185,5 +185,5 @@ body style:first-child,
 @include removed-class('.grav-c-list-img-cards', 3, 'Consider using .grav-c-list-cards-basic or .grav-o-two-column instead.');
 @include removed-class('.grav-c-two-columns-block', 3, 'Please use .grav-o-two-column instead.');
 @include removed-class('.grav-o-column-list', 3, 'Please use .grav-o-reset-list instead.');
-@include removed-class('.grav-c-icon__secondary-elements', 3, 'Consider using one of the .grav-svg-hl-1/2/3 classes to achieve a similar effect.');
-@include removed-class('.grav-c-logo', 3, 'Now redundant as inline SVG elements now get a default fill color.');
+@include removed-class('.grav-c-icon__secondary-elements', 3, 'Consider using one of the --grav-co-svg-hl-1/2/3 custom properties to achieve a similar effect.');
+@include removed-class('.grav-c-logo', 3, 'For logotype, use .grav-c-logotype instead. For other uses this class is now redundant as inline SVG elements now get a default fill color.');


### PR DESCRIPTION
**Description**
It turns out there was a flaw in our approach to letting parts of SVG symbols be recoloured. We had been selecting the classes that are used within the SVGs themselves (`grav-svg-hl-1 / 2 / 3`, which come from `gravity-particles`) and then applying certain colour purposes to them. However, this only works globally for all instances of those SVG symbols and does not allow the colouring to be altered or disabled on a case by case basis.

The reason is as follows: We inline all our SVG symbols on the page, but since they are `<symbol>` elements, they don't visually render. Wherever we then display one of those symbols, we create an `<svg>` element that contains a `<use>` element referencing the desired SVG symbol. This essentially clones that symbol's contents into the our `<svg>` and it appears in the browser.

Trouble is, it gets cloned into a shadow DOM:
<img width="457" alt="image" src="https://user-images.githubusercontent.com/16718916/77065019-6bc2c380-69d8-11ea-8e01-98f443a6f759.png">

...and thus our class selectors (which only apply to the parent page's "light" DOM) do *not* select the cloned symbol within our SVG. Therefore we can't restyle them using that approach.

Our classes _do_ however select the original, inlined symbols since those are part of the parent page's DOM. In other words, we're only selecting and thus recolouring the _original_ symbols, but can't then override that for cloned instances that sit inside shadow DOMs.

Fortunately though, some CSS values do get inherited across the shadow DOM boundary. The `currentColor` value is one - which is why parts of our SVG symbols without a `grav-svg-hl-*` class do take on the text colour of their surroundings. But, where we've overridden that for the original, we can't then modify it on a per-instance basis.

So, this change fixes that by:

1. Introducing some new CSS custom properties (which also get inherited across the shadow DOM boundary): `--grav-co-svg-hl-1 / 2 / 3`. However, at the root level, these are **not** set.
1. (Globally) styling the `.grav-svg-hl-*` classes to apply a fill of those new custom properties and, crucially, to use a fallback value of `currentColor` when they are not set. This is the styling that gets applied to the symbol originals.

With this, all SVGs will by default appear entirely filled using the `currentColor`. This seems like a sensible default since it's the plainest possibly styling of them.

But, thanks to the custom properties, we now have an escape hatch to selectively override them via class (or any other means of selecting specific instances where we _display_ SVGs).


One case where this is needed is the new Buildit 2.0 logo (which ships with recent versions of `gravity-particles`, is intended to have "buildit |" coloured separately from the rest. This change therefore introduces a new `.grav-c-logotype` class, which can applied to uses of that SVG, which sets the relevant custom properties to make the "buildit |" portion be filled with the group B accent colour purpose value:
<img width="318" alt="image" src="https://user-images.githubusercontent.com/16718916/77066215-a9c0e700-69da-11ea-8ff7-7ed631c2785d.png">
