### PR TITLE
chore(ci): streams semantic-release output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   - provider: script
     skip_cleanup: true
     script:
-      npm run semantic-release
+      npm run semantic-release -- --stream
   # deploy develop to Staging
   - provider: script
     script:


### PR DESCRIPTION
**Description**
Semantic release seemed to hang on the recent v3 release. However, it did seem to work - at least partially - since the NPM package was published, a git tag and changelog was pushed back to this repo and Github release notes were added.

However, because it didn't seem to exit the TravisCI build timed out and failed. Because of this, subsequent steps to publish the updated pattern library and CDN copy did not execute :-(

Sadly, the build log doesn't offer any clues. I've tried running the same command locally and it seems to complete fine. Maybe it was a one-off glitch?

Semantic release is executed via Lerna, which buffers the output until the command completes. That's why we never got to see whatever semantic release might have been outputting to the console. This commit therefore changes the behaviour to log the output as it happens.

Hopefully, if this siuation occurs again, it we might be able to get to the bottom of why it failed.
